### PR TITLE
App Replacement Fixes

### DIFF
--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -203,6 +203,7 @@ void showErrorModal(NSError* error) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                       showErrorModal(error);
                     });
+                    return;
                   }
                 }
                 

--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -208,6 +208,9 @@ bool checkPermission() {
               if (rename(sourcePath.fileSystemRepresentation,
                          targetPath.fileSystemRepresentation) != 0) {
                 // If rename() failed, try to do this by moving the contents instead
+                // Advantage of this approach is that we don't need any special permissions if the user is the owner of the folder (User initiated drag and drop)
+                // Disadvantage of this approach is that the metadata update isn't reliable, if the icon of the app and the replaced app are different, user may need a restart before the icon updates in the dock.
+                
                 NSDirectoryEnumerator* enumerator = [fileManager enumeratorAtPath:sourcePath];
                 NSString* file;
 

--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -205,6 +205,8 @@ void showErrorModal(NSError* error) {
                     });
                   }
                 }
+                
+                // Trigger icon updation
                 runCommand(@"/usr/bin/touch", @[ NSBundle.mainBundle.bundlePath ]);
                 runCommand(@"/usr/bin/touch",
                            @[ [NSBundle.mainBundle.bundlePath

--- a/AppDelegate.mm
+++ b/AppDelegate.mm
@@ -55,12 +55,12 @@ void showErrorModal(NSError* error) {
   showErrorModal(errorDescription);
 }
 
-bool checkPermission() {
+bool isBundleWritable() {
   auto* testDir = [NSBundle.mainBundle.bundlePath stringByAppendingPathComponent:@"test"];
   auto* fileManager = NSFileManager.defaultManager;
-  bool result = [fileManager createDirectoryAtPath:testDir withIntermediateDirectories:true attributes:NULL error:NULL];
+  bool result = [fileManager createDirectoryAtPath:testDir withIntermediateDirectories:true attributes:nil error:nil];
   if (result) {
-    [fileManager removeItemAtPath:testDir error:NULL];
+    [fileManager removeItemAtPath:testDir error:nil];
     return true;
   } else {
     return false;
@@ -119,7 +119,7 @@ bool checkPermission() {
   NSURL* downloadURL = [NSURL URLWithString:[downloadURLs valueForKey:ARCH_KEY_NAME]];
   NSString* targetAppName = [info valueForKey:@"TargetAppName"];
 
-  if (!checkPermission()) {
+  if (!isBundleWritable()) {
     // If permission check fails, it's likely to be a standard user, let's rerun the program
     // as root
     


### PR DESCRIPTION
Making the following fixes to App replacement flow:
 * Downloaded app gets unzipped within the Bundle
_We do this so that the app is downloaded to the same disk as its final move destination. The failure of this also let's us know if we need to re-run this script as admin as the same permissions are required for the subsequent steps._
 * Re-run the whole install in Admin mode on failure
_Instead of individual STPrivilegeTask fallbacks we run the whole script under admin._
 * New `move` fallback strategy where we move contents instead of parent
_We should do this as this doesn't require any administrative privileges. Avoiding administrative privileges is also good as it makes sure that the standard user remains the owner of the internal files and this may help software update privileges._

Scenarios Tested:
* Admin user downloads and runs app in Application dir
* Standard user downloads and runs app in Application dir
* Admin user pastes app in Application dir and then logs out and logs in as standard user and standard user runs app