### PR TITLE
Add position to string format specifiers for localization

### DIFF
--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -1,11 +1,11 @@
-/* Title of dialog shown when automatic installation has failed. %@ is the name of the app. */
-"errorDialog.title" = "%@ Automatic Installation Failed";
+/* Title of dialog shown when automatic installation has failed. %1$@ is the name of the app. */
+"errorDialog.title" = "%1$@ Automatic Installation Failed";
 
-/* Message in dialog shown when automatic installation has failed, prompting user to download manually. %@ is the name of the app. */
-"errorDialog.downloadManuallyMessage" = "Download %@ manually to continue.";
+/* Message in dialog shown when automatic installation has failed, prompting user to download manually. %1$@ is the name of the app. */
+"errorDialog.downloadManuallyMessage" = "Download %1$@ manually to continue.";
 
-/* Message in dialog shown when automatic installation has failed, prompting user to contact support. This message is followed by an error shown on the next line.  %@ is the name of the app. */
-"errorDialog.contactSupportMessage" = "You may also contact %@ support with this error information:";
+/* Message in dialog shown when automatic installation has failed, prompting user to contact support. This message is followed by an error shown on the next line.  %1$@ is the name of the app. */
+"errorDialog.contactSupportMessage" = "You may also contact %1$@ support with this error information:";
 
 /* Button in dialog shown when automatic installation has failed. Clicking this button will open a URL for the user to manually download the app. */
 "errorDialog.downloadManuallyButton" = "Download manually";
@@ -13,8 +13,8 @@
 /* Title of a dialog prompting user to move the app into their macOS Applications folder. */
 "moveToApplicationsDialog.title" = "Move to Applications Folder";
 
-/* Message in dialog prompting user to move the app into their macOS Applications folder. %@ is the name of the app. This message is broken into two parts, with "\n\n" included to generate an empty line between the two parts. */
-"moveToApplicationsDialog.message" = "Please move the %@ app into the Applications folder and try again.\n\nIf the app is already in the Applications folder, drag it into some other folder and then back into Applications.";
+/* Message in dialog prompting user to move the app into their macOS Applications folder. %1$@ is the name of the app. This message is broken into two parts, with "\n\n" included to generate an empty line between the two parts. */
+"moveToApplicationsDialog.message" = "Please move the %1$@ app into the Applications folder and try again.\n\nIf the app is already in the Applications folder, drag it into some other folder and then back into Applications.";
 
 /* Label for a generic confirmation button that acknowledges some message. */
 "dialog.okButton" = "OK";
@@ -22,29 +22,29 @@
 /* Label for the generic cancel button that closes dialogs without taking an action. */
 "dialog.cancelButton" = "Cancel";
 
-/* Error message shown alongside its numeric code. %@ is the error message itself, and %ld is the numeric code for that error message. */
-"error.errorWithCode" = "%@ (code %ld)";
+/* Error message shown alongside its numeric code. %1$@ is the error message itself, and %2$ld is the numeric code for that error message. */
+"error.errorWithCode" = "%1$@ (code %2$ld)";
 
-/* Generic error message shown when initial installer checks fail. %i is the numeric code of the error. */
-"error.initialCheckFailed" = "Initial check failed: %i";
+/* Generic error message shown when initial installer checks fail. %1$i is the numeric code of the error. */
+"error.initialCheckFailed" = "Initial check failed: %1$i";
 
 /* Error message shown when the installer does not have the required permissions to install the app. */
 "error.wrongPermissions" = "You do not have the necessary permissions required to autoinstall this app.";
 
-/* Error message shown when the app fails to download due to an HTTP error. %lu is the numeric error code for the HTTP error. */
-"error.downloadFailed" = "Failed to download, HTTP: %lu";
+/* Error message shown when the app fails to download due to an HTTP error. %1$lu is the numeric error code for the HTTP error. */
+"error.downloadFailed" = "Failed to download, HTTP: %1$lu";
 
-/* Error message shwon when the installer fails to extract the zipped application. %i is the numeric code of the error. */
-"error.extractFailed" = "Failed to extract: %i";
+/* Error message shwon when the installer fails to extract the zipped application. %1$i is the numeric code of the error. */
+"error.extractFailed" = "Failed to extract: %1$i";
 
-/* Title of the installer dialog. %@ is the name of the app that is being installed. */
-"installerDialog.title" = "%@ Installer";
+/* Title of the installer dialog. %1$@ is the name of the app that is being installed. */
+"installerDialog.title" = "%1$@ Installer";
 
-/* Message shown in the installer dialog indicating that the app is currently being downloaded. %@ is the name of the app. */
-"installerDialog.downloadingMessage" = "Downloading %@...";
+/* Message shown in the installer dialog indicating that the app is currently being downloaded. %1$@ is the name of the app. */
+"installerDialog.downloadingMessage" = "Downloading %1$@...";
 
-/* Message shwon in the installer dialog indicating that the app is now being installed. %@ is the name of the app. */
-"installerDialog.installingMessage" = "Installing %@...";
+/* Message shwon in the installer dialog indicating that the app is now being installed. %1$@ is the name of the app. */
+"installerDialog.installingMessage" = "Installing %1$@...";
 
-/* Label for menu item used to quit the application. %@ is the name of the application. */
-"menu.quitItem" = "Quit %@";
+/* Label for menu item used to quit the application. %1$@ is the name of the application. */
+"menu.quitItem" = "Quit %1$@";


### PR DESCRIPTION
Let's improve the ease of translation for the strings in this project by adding explicit indices to format specifiers. This allows reordering format specifiers in translations while still referencing the correct argument to `stringWithFormat`.

Tested by manually logging all affected strings and verified they are still correctly formatted.