### PR TITLE
Desktop: updates actions/upload-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           xcodebuild -project DynamicUniversalApp.xcodeproj -configuration Release
 
       - name: Store build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build/Release


### PR DESCRIPTION
Noticed CI was failing on [#16](https://github.com/figma/dynamic-universal-app/pull/16) with the following error 

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

so I just updated the version. 

Test Plan: 
ci