### PR TITLE
desktop: add es-la translations to dynamic installer

### DIFF
--- a/DynamicUniversalApp.xcodeproj/project.pbxproj
+++ b/DynamicUniversalApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		611C771B2DBB0CF000427809 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 611C77132DBB0CF000427809 /* Localizable.strings */; };
 		611C771C2DBB0CF000427809 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 611C77162DBB0CF000427809 /* Localizable.strings */; };
 		611C771D2DBB0CF000427809 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 611C77192DBB0CF000427809 /* Localizable.strings */; };
+		6972FEFB2E0F384500CDE7A4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6972FEF92E0F384500CDE7A4 /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		611C77122DBB0CF000427809 /* es-es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-es"; path = Localizable.strings; sourceTree = "<group>"; };
 		611C77152DBB0CF000427809 /* ko-kr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ko-kr"; path = Localizable.strings; sourceTree = "<group>"; };
 		611C77182DBB0CF000427809 /* pt-br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-br"; path = Localizable.strings; sourceTree = "<group>"; };
+		6972FEF82E0F384500CDE7A4 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -47,6 +49,7 @@
 		2722725E263AD71300AFC28A = {
 			isa = PBXGroup;
 			children = (
+				6972FEFA2E0F384500CDE7A4 /* es-419.lproj */,
 				40B4470B28511CFC00E28ED2 /* ja.lproj */,
 				4000AD3B283D8A4800D07897 /* en.lproj */,
 				2722726A263AD71300AFC28A /* AppDelegate.h */,
@@ -92,6 +95,14 @@
 				611C77192DBB0CF000427809 /* Localizable.strings */,
 			);
 			path = "pt-br.lproj";
+			sourceTree = "<group>";
+		};
+		6972FEFA2E0F384500CDE7A4 /* es-419.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				6972FEF92E0F384500CDE7A4 /* Localizable.strings */,
+			);
+			path = "es-419.lproj";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -142,6 +153,7 @@
 				"ko-KR",
 				"pt-BR",
 				"es-ES",
+				"es-419",
 			);
 			mainGroup = 2722725E263AD71300AFC28A;
 			productRefGroup = 27227268263AD71300AFC28A /* Products */;
@@ -161,6 +173,7 @@
 				27D3053E263D28BC00BBEBA5 /* App.xib in Resources */,
 				40B4470C28511CFC00E28ED2 /* ja.lproj in Resources */,
 				4000AD3C283D8A4800D07897 /* en.lproj in Resources */,
+				6972FEFB2E0F384500CDE7A4 /* Localizable.strings in Resources */,
 				611C771B2DBB0CF000427809 /* Localizable.strings in Resources */,
 				611C771C2DBB0CF000427809 /* Localizable.strings in Resources */,
 				611C771D2DBB0CF000427809 /* Localizable.strings in Resources */,
@@ -203,6 +216,14 @@
 			isa = PBXVariantGroup;
 			children = (
 				611C77182DBB0CF000427809 /* pt-br */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		6972FEF92E0F384500CDE7A4 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6972FEF82E0F384500CDE7A4 /* es-419 */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/es-419.lproj/Localizable.strings
+++ b/es-419.lproj/Localizable.strings
@@ -1,0 +1,50 @@
+/* Title of dialog shown when automatic installation has failed. %1$@ is the name of the app. */
+"errorDialog.title" = "Error en la instalación automática de %1$@";
+
+/* Message in dialog shown when automatic installation has failed, prompting user to download manually. %1$@ is the name of the app. */
+"errorDialog.downloadManuallyMessage" = "Descarga %1$@ manualmente para continuar.";
+
+/* Message in dialog shown when automatic installation has failed, prompting user to contact support. This message is followed by an error shown on the next line.  %1$@ is the name of the app. */
+"errorDialog.contactSupportMessage" = "También puedes contactar al Soporte de %1$@ con la siguiente información del error:";
+
+/* Button in dialog shown when automatic installation has failed. Clicking this button will open a URL for the user to manually download the app. */
+"errorDialog.downloadManuallyButton" = "Descargar manualmente";
+
+/* Title of a dialog prompting user to move the app into their macOS Applications folder. */
+"moveToApplicationsDialog.title" = "Mover a la carpeta Aplicaciones";
+
+/* Message in dialog prompting user to move the app into their macOS Applications folder. %1$@ is the name of the app. This message is broken into two parts, with "\n\n" included to generate an empty line between the two parts. */
+"moveToApplicationsDialog.message" = "Mueve la app %1$@ a la carpeta Aplicaciones e inténtalo nuevamente.\n\nSi la app ya está en la carpeta Aplicaciones, arrástrala a otra carpeta y, luego, regresa a Aplicaciones.";
+
+/* Label for a generic confirmation button that acknowledges some message. */
+"dialog.okButton" = "Aceptar";
+
+/* Label for the generic cancel button that closes dialogs without taking an action. */
+"dialog.cancelButton" = "Cancelar";
+
+/* Error message shown alongside its numeric code. %1$@ is the error message itself, and %2$ld is the numeric code for that error message. */
+"error.errorWithCode" = "%1$@ (código %2$ld)";
+
+/* Generic error message shown when initial installer checks fail. %1$i is the numeric code of the error. */
+"error.initialCheckFailed" = "Error en la comprobación inicial: %1$i";
+
+/* Error message shown when the installer does not have the required permissions to install the app. */
+"error.wrongPermissions" = "No tienes los permisos necesarios para instalar esta app automáticamente.";
+
+/* Error message shown when the app fails to download due to an HTTP error. %1$lu is the numeric error code for the HTTP error. */
+"error.downloadFailed" = "No se pudo descargar, HTTP: %1$lu";
+
+/* Error message shwon when the installer fails to extract the zipped application. %1$i is the numeric code of the error. */
+"error.extractFailed" = "No se pudo extraer: %1$i";
+
+/* Title of the installer dialog. %1$@ is the name of the app that is being installed. */
+"installerDialog.title" = "Instalador de %1$@";
+
+/* Message shown in the installer dialog indicating that the app is currently being downloaded. %1$@ is the name of the app. */
+"installerDialog.downloadingMessage" = "Descargando %1$@...";
+
+/* Message shwon in the installer dialog indicating that the app is now being installed. %1$@ is the name of the app. */
+"installerDialog.installingMessage" = "Instalando %1$@...";
+
+/* Label for menu item used to quit the application. %1$@ is the name of the application. */
+"menu.quitItem" = "Salir de %1$@";


### PR DESCRIPTION
**What?**

Adds Spanish (`es-la`) strings to the installer

**Test Plan:**
- [x] Test a package build